### PR TITLE
fix(resolve-weight): check extrabold before bold

### DIFF
--- a/src/custom.ts
+++ b/src/custom.ts
@@ -88,9 +88,9 @@ const resolveWeight = (weightOrSrc?: string | number) => {
   if (weightOrSrc.includes('medium')) return 500
   if (weightOrSrc.includes('semibold')) return 600
   if (weightOrSrc.includes('demibold')) return 600
-  if (weightOrSrc.includes('bold')) return 700
   if (weightOrSrc.includes('extrabold')) return 800
   if (weightOrSrc.includes('ultrabold')) return 800
+  if (weightOrSrc.includes('bold')) return 700
   if (weightOrSrc.includes('black')) return 900
   if (weightOrSrc.includes('heavy')) return 900
   return 400


### PR DESCRIPTION
The font label `extrabold`, includes the keyword `bold` too. So he needs to be checked before bold to work correctly

Title font before:
![Captura de tela 2022-06-23 222543](https://user-images.githubusercontent.com/16389212/175451906-0757915f-edb4-43b7-8ac3-387ddfec8a1d.png)

Generated CSS:
![Captura de tela 2022-06-23 230040](https://user-images.githubusercontent.com/16389212/175452120-8fd9324c-22e7-42e0-bc10-3c29d1fd1646.png)

Title font after:
![Captura de tela 2022-06-23 222251](https://user-images.githubusercontent.com/16389212/175452087-4d68c8b1-72ae-4250-860d-6ad260d7990d.png)

