### PR TITLE
feat: add support for vite 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint --fix ."
   },
   "peerDependencies": {
-    "vite": "^2.0.0"
+    "vite": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
     "fast-glob": "^3.2.11"


### PR DESCRIPTION
## Description of Problem

We have install problem at resolving peerDependencies.

```
❯ ni 
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: some-project@1.0.0
npm ERR! Found: vite@3.0.2
npm ERR! node_modules/vite
npm ERR!   dev vite@"^3.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer vite@"^2.0.0" from vite-plugin-fonts@0.5.0
npm ERR! node_modules/vite-plugin-fonts
npm ERR!   dev vite-plugin-fonts@"^0.5.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/naoki.endo/.npm/eresolve-report.txt for a full report.
...
```

## Proposed Solution

Add Vite 3 support.

## Additional Information

No test.

close #24 
